### PR TITLE
Reuse runner pane

### DIFF
--- a/hsandbox
+++ b/hsandbox
@@ -324,7 +324,10 @@ class EventHandler(ProcessEvent):
     def process_IN_MODIFY(self, event):
         if event.pathname == os.path.join(os.getcwd(), self.hacking.filename):
             if self.process:
-                os.killpg(self.process.pid, signal.SIGKILL)
+                subprocess.call([
+                    "tmux",
+                    "respwan-pane", "-t", "Sandbox:0", ";",
+                    ])
             def preexec_fn():
                 os.setpgid(0, 0)
             os.system("clear")
@@ -354,8 +357,10 @@ def screen(hacking, argv, vertical):
                 "tmux",
                 "new-session", "-n", "Sandbox", hsandbox + " --editor", ";",
                 "set-option", "-q", "status", "off", ";",
+                "set-option", "remain-on-exit", ";",
                 "split-window", splitopt, hsandbox + " --runner", ";",
                 "last-pane", ";",
+                "set-option", "remain-on-exit", "off", ";",
             ])
         except OSError:
             raise Error("Couldn't run 'screen'.  Is it installed?")


### PR DESCRIPTION
Start the runner pane with `remain-on-exit` option, so that
when an error is thrown during the Evaluate phase,
the error is clearly indicated in the runner pane.
We also respawn the runner pane when further edits are
made in the editor pane. This allows the new output
(or a new error) to be displayed in the runner pane.

'hsandbox' is terminated when the editor pane is terminated.
