### PR TITLE
Improve shebang portability.

### DIFF
--- a/hsandbox
+++ b/hsandbox
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 """
 The Hacking Sandbox - hsandbox
 


### PR DESCRIPTION
Two things:

1. Use /usr/bin/env; this means we get python from $PATH; it isn't in
   /usr/bin on all systems.
2. Specify python 2; the script doesn't work on python 3, and the
   `python` executable is not always python 2. (c.f. Archlinux).
   The versioned executables (`python2`/`python3`) Have been available
   on every system I've encountered, regardless of what `python` points
   to.