### PR TITLE
Use /usr/bin/env for the shebang

### DIFF
--- a/hsandbox
+++ b/hsandbox
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 The Hacking Sandbox - hsandbox
 


### PR DESCRIPTION
This allows the script to run in environments where the `python` executable is located somewhere other than `/usr/bin`.