### PR TITLE
go fmt before running

### DIFF
--- a/hsandbox
+++ b/hsandbox
@@ -115,7 +115,8 @@ class GoHacking(Hacking):
                 "func main() {\n<cursor>\n}\n")
 
     def get_command(self, version):
-        return "go run " + self.filename
+        return ("go fmt " + self.filename + " && "
+                "go run " + self.filename)
 
 class RustHacking(Hacking):
 


### PR DESCRIPTION
Hi!

I'd like to add invocation of `go fmt` before `go run`. Then the file can be reloaded by `:e` in the vi session.

Thanks in advance!
Wojtek